### PR TITLE
Add buildSrc to hold dependency management

### DIFF
--- a/bloom/build.gradle
+++ b/bloom/build.gradle
@@ -1,3 +1,5 @@
+import com.fjoglar.composechallenge.buildsrc.Libs
+
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
@@ -14,6 +16,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
         vectorDrawables {
             useSupportLibrary true
         }
@@ -25,21 +28,25 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
         useIR = true
     }
+
     buildFeatures {
         compose true
     }
+
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.5.21'
+        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
     }
+
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
@@ -49,17 +56,16 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.4.0-beta01'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+    implementation Libs.AndroidX.coreKtx
+    implementation Libs.AndroidX.appcompat
+
+    implementation Libs.Google.material
+
+    implementation Libs.AndroidX.Compose.ui
+    implementation Libs.AndroidX.Compose.material
+    implementation Libs.AndroidX.Compose.toolingPreview
+
+    implementation Libs.AndroidX.Activity.activityCompose
+
+    debugImplementation Libs.AndroidX.Compose.tooling
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,15 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+import com.fjoglar.composechallenge.buildsrc.Libs
+
 buildscript {
-    ext {
-        compose_version = '1.0.3'
-    }
+
     repositories {
         google()
         mavenCentral()
     }
-    dependencies {
-        classpath "com.android.tools.build:gradle:7.0.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.30"
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+    dependencies {
+        classpath Libs.androidGradlePlugin
+        classpath Libs.Kotlin.gradlePlugin
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+repositories {
+    mavenCentral()
+}
+
+plugins {
+    `kotlin-dsl`
+}

--- a/buildSrc/src/main/java/com/fjoglar/composechallenge/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/java/com/fjoglar/composechallenge/buildsrc/Dependencies.kt
@@ -1,0 +1,33 @@
+package com.fjoglar.composechallenge.buildsrc
+
+object Libs {
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.0.2"
+
+    object Kotlin {
+        private const val version = "1.5.30"
+        const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
+    }
+
+    object Google {
+        const val material = "com.google.android.material:material:1.4.0"
+    }
+
+    object AndroidX {
+        const val coreKtx = "androidx.core:core-ktx:1.6.0"
+        const val appcompat = "androidx.appcompat:appcompat:1.3.1"
+
+        object Activity {
+            const val activityCompose = "androidx.activity:activity-compose:1.4.0-beta01"
+        }
+
+        object Compose {
+            const val version = "1.0.3"
+
+            const val ui = "androidx.compose.ui:ui:$version"
+            const val material = "androidx.compose.material:material:$version"
+
+            const val toolingPreview = "androidx.compose.ui:ui-tooling-preview:$version"
+            const val tooling = "androidx.compose.ui:ui-tooling:$version"
+        }
+    }
+}


### PR DESCRIPTION
This way all dependency management is centralized, to avoid version inconsistency when in the future we add more modules.